### PR TITLE
Handle pointers to slice of custom types

### DIFF
--- a/field.go
+++ b/field.go
@@ -25,27 +25,36 @@ type Field struct {
 }
 
 // NewField returns a Field initialized from v.
-// If field is provided, indicate the Field was parsed from a StructField.
-func NewField(v interface{}, field ...reflect.StructField) Field {
+// If fields is provided, its first item indicates the Field was parsed from a StructField.
+func NewField(v interface{}, fields ...reflect.StructField) Field {
 	if v == nil {
 		return Field{}
 	}
-	f := reflect.StructField{}
-	hasStructField := false
-	if len(field) > 0 {
-		f = field[0]
-		hasStructField = true
+	var structField *reflect.StructField
+	if len(fields) > 0 {
+		structField = &fields[0]
 	}
+	return newField(v, true, structField)
+}
+
+func newField(v interface{}, deference bool, field *reflect.StructField) Field {
 	t := reflect.TypeOf(v)
-	return Field{
-		v,
-		t,
-		t.Kind(),
-		reflect.ValueOf(v),
-		nil,
-		f,
-		hasStructField,
+	k := t.Kind()
+	if deference && k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
 	}
+	result := Field{
+		Interface: v,
+		Type:      t,
+		Kind:      k,
+		Value:     reflect.ValueOf(v),
+	}
+	if field != nil {
+		result.StructField = *field
+		result.FromStructField = true
+	}
+	return result
 }
 
 // Return true if f was created from nil.

--- a/sashay.go
+++ b/sashay.go
@@ -185,7 +185,7 @@ func (sa *Sashay) DefineDataType(i interface{}, dt DataTyper) {
 	sa.dataTypesForTypes[f.Type] = dataTypeDef{f, dt}
 	if f.Kind != reflect.Ptr {
 		ptr := reflect.New(f.Type)
-		ptrF := NewField(ptr.Interface())
+		ptrF := newField(ptr.Interface(), false, nil)
 		sa.dataTypesForTypes[ptrF.Type] = dataTypeDef{ptrF, dt}
 	}
 }


### PR DESCRIPTION
If a user used a *[]MyType slice in params or responses,
a panic would be raised looking for the data type definition
for *[]MyType. This is because the pointer-to-slice wasn't recognized
as a "thing that should be walked", it was instead recognized
as a "type to export directly".
Fixing this required NewField to take pointer values
and dereference to the underlying type.

However, there are times we don't want to dereference
(like when registering a custom data type definition,
we also want to register the "pointer version" of the type/value).
So I added an internal newField method.

Fixes #4 
Also as I was fixing this it exposed some inconsistencies with how exported types are handled (written as $ref or not) which I'll fix separately.