### PR TITLE
Fix $ref being used for exported parameter types

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -343,6 +343,10 @@ The actual getUsersHandler code uses the same struct to describe itself as it do
 The same is true for response types- the schema is built from the real objects, with the json struct tags,
 not separate documentation.
 
+Note that Sashay never uses $ref for parameters (resources in POST/PUT request bodies).
+Even if the same type is used for a request and a response,
+it'll be expanded in the requestBody section and a $ref in the response section.
+This may change in the future.
 
 Sashay Detail- Request Bodies
 

--- a/sashay.go
+++ b/sashay.go
@@ -232,15 +232,6 @@ func (sa *Sashay) isMappedToDataType(f Field) bool {
 	return found
 }
 
-// A type will end up in the schema if it has a name and is exported.
-// No name is anonymous, so much be traversed. Assume lowercase named isn't meant for the swagger doc.
-func isTypeForSchema(t reflect.Type) bool {
-	if t.Name() == "" {
-		return false
-	}
-	return isExportedName(t.Name())
-}
-
 // Assuming field.Type is a struct, enumerate all the exported fields as Fields.
 func enumerateStructFields(field Field) Fields {
 	result := make(Fields, 0)

--- a/sashay_test.go
+++ b/sashay_test.go
@@ -1085,6 +1085,63 @@ components:
 `))
 	})
 
+	It("expands fields of parameters (do not use $ref)", func() {
+		type Address struct {
+			Address1 string `json:"address1"`
+			State    string `json:"state"`
+		}
+		type User struct {
+			Name    string  `json:"name"`
+			Address Address `json:"address"`
+			OldAddresses []Address `json:"oldAddresses"`
+		}
+		sw.Add(sashay.NewOperation(
+			"POST",
+			"/users",
+			"Create a user.",
+			User{},
+			nil,
+			nil,
+		))
+		yaml := sw.BuildYAML()
+		Expect(yaml).To(HaveSuffix(`paths:
+  /users:
+    post:
+      operationId: postUsers
+      summary: Create a user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                address:
+                  type: object
+                  properties:
+                    address1:
+                      type: string
+                    state:
+                      type: string
+                oldAddresses:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      address1:
+                        type: string
+                      state:
+                        type: string
+      responses:
+        '204':
+          description: The operation completed successfully.
+        'default':
+          description: error response
+`))
+	})
+
 	It("can create a new registry by filtering/mapping operations", func() {
 		sw.DefaultContentType = "application/xml"
 		sw.AddServer("server.com", "the server")


### PR DESCRIPTION
If the parameter type had an exported field of an exported type,
it would show up in the requestBody as a $ref,
without a corresponding entry in the schemas portion of the doc.

This change makes it so struct fields will *always* be
expanded for request bodies, even if they are an exported type.
This is not consistent with how response shapes work
($ref is used for exported types, expansion for unexported).
Parameters were set up to be more expansion-heavy from the start,
but we can revisit this if it's a problem in practice
(the swagger is still correct, just more verbose).