### PR TITLE
Support maps and slices in operations

### DIFF
--- a/data_types.go
+++ b/data_types.go
@@ -99,6 +99,10 @@ func BuiltinDataTyperFor(value interface{}, chained ...DataTyper) DataTyper {
 		dt = SimpleDataTyper("number", "float")
 	case time.Time, *time.Time:
 		dt = SimpleDataTyper("string", "date-time")
+	case map[string]interface{}:
+		dt = SimpleDataTyper("object", "")
+	case []interface{}, []map[string]interface{}:
+		dt = SimpleDataTyper("array", "")
 	}
 	typers := []DataTyper{dt, defaultDataTyper}
 	typers = append(typers, chained...)

--- a/sashay.go
+++ b/sashay.go
@@ -56,7 +56,19 @@ func New(title, description, version string) *Sashay {
 // BuiltinDataTypeValues is a slice of values of all supported data types.
 // Use it for when you want to define custom DataTypers for the builtin types,
 // like if you are parsing validations.
-var BuiltinDataTypeValues = []interface{}{int(0), int64(0), int32(0), "", false, float64(0), float32(0), time.Time{}}
+var BuiltinDataTypeValues = []interface{}{
+	int(0),
+	int64(0),
+	int32(0),
+	"",
+	false,
+	float64(0),
+	float32(0),
+	time.Time{},
+	make(map[string]interface{}, 0),
+	make([]map[string]interface{}, 0),
+	make([]interface{}, 0),
+}
 
 // Add registers a Swagger operations and all the associated types.
 func (sa *Sashay) Add(op Operation) Operation {

--- a/sashay_test.go
+++ b/sashay_test.go
@@ -1284,4 +1284,105 @@ paths:
 		contents, err := ioutil.ReadFile(f.Name())
 		Expect(string(contents)).To(ContainSubstring("SwaggerGenAPI"))
 	})
+
+	It("can handle maps", func() {
+		sw.Add(sashay.NewOperation(
+			"GET",
+			"/users",
+			"",
+			map[string]interface{}{},
+			map[string]interface{}{},
+			map[string]interface{}{},
+		))
+		Expect(sw.BuildYAML()).To(ContainSubstring(`paths:
+  /users:
+    get:
+      operationId: getUsers
+      requestBody:
+        content:
+          */*:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: ok response
+          content:
+            application/json:
+              schema:
+                type: object
+        'default':
+          description: error response
+          content:
+            application/json:
+              schema:
+                type: object`))
+	})
+	It("can handle interface slices", func() {
+		sw.Add(sashay.NewOperation(
+			"GET",
+			"/users",
+			"",
+			[]interface{}{},
+			[]interface{}{},
+			[]interface{}{},
+		))
+		Expect(sw.BuildYAML()).To(ContainSubstring(`paths:
+  /users:
+    get:
+      operationId: getUsers
+      requestBody:
+        content:
+          */*:
+            schema:
+              type: array
+      responses:
+        '200':
+          description: ok response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+        'default':
+          description: error response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:`))
+	})
+	It("can handle subtypes of maps", func() {
+		type submap map[string]interface{}
+		sw.DefineDataType(submap{}, sashay.SimpleDataTyper("object", ""))
+		sw.Add(sashay.NewOperation(
+			"GET",
+			"/users",
+			"",
+			submap{},
+			submap{},
+			submap{},
+		))
+		Expect(sw.BuildYAML()).To(ContainSubstring(`paths:
+  /users:
+    get:
+      operationId: getUsers
+      requestBody:
+        content:
+          */*:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: ok response
+          content:
+            application/json:
+              schema:
+                type: object
+        'default':
+          description: error response
+          content:
+            application/json:
+              schema:
+                type: object`))
+	})
 })


### PR DESCRIPTION
If an API does not use typed fields (meaningfuls tructs) we can at least throw it into requestBody,
or a generic 'object' or 'array' schema.